### PR TITLE
Change install script to check for armv6/7 instead of Raspbian

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ if [ "$PREREQ_PACKAGES_TO_INSTALL" ]; then
     sudo apt-get -y install $PREREQ_PACKAGES_TO_INSTALL
 fi
 
-if lsb_release -si | fgrep -ivq raspbian; then
+if uname -a | grep -Eivq 'armv7|armv6'; then
     run_on_pi_only
 fi
 


### PR DESCRIPTION
As the compile target is arm-unknown-linux-gnueabihf, checking for armv6 / armv7 should also work to detect compatible devices. 

Fixes #49.

Tested on:
- RPI 3 with OSMC
- RPI 2B with Raspbian
- RPI Zero W with Raspbian 