### PR TITLE
Added log level for librespot to control syslog verbosity.

### DIFF
--- a/raspotify/etc/default/raspotify
+++ b/raspotify/etc/default/raspotify
@@ -32,3 +32,6 @@
 # Backend could be set to pipe here, but it's for very advanced use cases of
 # librespot, so you shouldn't need to change this under normal circumstances.
 #BACKEND_ARGS="--backend alsa"
+
+# Log level for librespot. Possible values are: debug, error, info, warn or trace
+#RUST_LOG=error

--- a/raspotify/lib/systemd/system/raspotify.service
+++ b/raspotify/lib/systemd/system/raspotify.service
@@ -14,6 +14,7 @@ Environment="BITRATE=160"
 Environment="CACHE_ARGS=--disable-audio-cache"
 Environment="VOLUME_ARGS=--enable-volume-normalisation --linear-volume --initial-volume=100"
 Environment="BACKEND_ARGS=--backend alsa"
+Environment="RUST_LOG=error"
 EnvironmentFile=-/etc/default/raspotify
 ExecStart=/usr/bin/librespot --name ${DEVICE_NAME} $BACKEND_ARGS --bitrate ${BITRATE} $CACHE_ARGS $VOLUME_ARGS $OPTIONS
 


### PR DESCRIPTION
I noticed that librespot creates a lot of log output. In one case it logged so many warnings about not being able to play a song until my raspberry pi's disk was full and died.
This change will cause it to only log errors by default instead of everything. The level can be configured via the config file.