### PR TITLE
Support passwords with special characters

### DIFF
--- a/raspotify/etc/default/raspotify
+++ b/raspotify/etc/default/raspotify
@@ -12,13 +12,14 @@
 # config at `/lib/systemd/system/raspotify.service` for more technical details.)
 #
 # To make your device visible on Spotify Connect across the Internet add your
-# username and password which can be set via "Set device password", on your
-# account settings, use `--username` and `--password`.
+# username and password which can be set via "Set device password"
 #
 # To choose a different output device (ie a USB audio dongle or HDMI audio out),
 # use `--device` with something like `--device hw:0,1`. Your mileage may vary.
 #
-#OPTIONS="--username <USERNAME> --password <PASSWORD>"
+#OPTIONS="--device hw:0,0"
+#USERNAME="<USERNAME>"
+#PASSWORD="<PASSWORD>"
 
 # Uncomment to use a cache for downloaded audio files. Cache is disabled by
 # default. It's best to leave this as-is if you want to use it, since

--- a/raspotify/lib/systemd/system/raspotify.service
+++ b/raspotify/lib/systemd/system/raspotify.service
@@ -15,7 +15,7 @@ Environment="CACHE_ARGS=--disable-audio-cache"
 Environment="VOLUME_ARGS=--enable-volume-normalisation --linear-volume --initial-volume=100"
 Environment="BACKEND_ARGS=--backend alsa"
 EnvironmentFile=-/etc/default/raspotify
-ExecStart=/usr/bin/librespot --name ${DEVICE_NAME} $BACKEND_ARGS --bitrate ${BITRATE} $CACHE_ARGS $VOLUME_ARGS $OPTIONS
+ExecStart=/usr/bin/librespot --name "${DEVICE_NAME}" $BACKEND_ARGS --bitrate "${BITRATE}" $CACHE_ARGS $VOLUME_ARGS --username "${USERNAME}" --password "${PASSWORD}" $OPTIONS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
My Spotify password, like all my other passwords, is randomly generated by a password manager. It happened to contain special characters that, because of the lack of quoting of the OPTIONS variable, got interpreted by the shell, causing it to not be understood by librespot.

This fixes that issue by introducing a new USERNAME and PASSWORD field in the config, which are quoted, to ensure special characters in the username and password do not break anything.