### PR TITLE
Update default config with new librespot volume-ctrl option

### DIFF
--- a/raspotify/etc/default/raspotify
+++ b/raspotify/etc/default/raspotify
@@ -27,7 +27,7 @@
 
 # By default, the volume normalization is enabled, add alternative volume
 # arguments here if you'd like, but these should be fine.
-#VOLUME_ARGS="--enable-volume-normalisation --linear-volume --initial-volume=100"
+#VOLUME_ARGS="--enable-volume-normalisation --volume-ctrl=linear --initial-volume=100"
 
 # Backend could be set to pipe here, but it's for very advanced use cases of
 # librespot, so you shouldn't need to change this under normal circumstances.

--- a/raspotify/lib/systemd/system/raspotify.service
+++ b/raspotify/lib/systemd/system/raspotify.service
@@ -12,7 +12,7 @@ ExecStartPre=/bin/mkdir -m 0755 -p /var/cache/raspotify ; /bin/chown raspotify:r
 Environment="DEVICE_NAME=raspotify (%H)"
 Environment="BITRATE=160"
 Environment="CACHE_ARGS=--disable-audio-cache"
-Environment="VOLUME_ARGS=--enable-volume-normalisation --linear-volume --initial-volume=100"
+Environment="VOLUME_ARGS=--enable-volume-normalisation --volume-ctrl=linear --initial-volume=100"
 Environment="BACKEND_ARGS=--backend alsa"
 EnvironmentFile=-/etc/default/raspotify
 ExecStart=/usr/bin/librespot --name ${DEVICE_NAME} $BACKEND_ARGS --bitrate ${BITRATE} $CACHE_ARGS $VOLUME_ARGS $OPTIONS


### PR DESCRIPTION
Adapts to the changes from https://github.com/librespot-org/librespot/pull/447. Otherwise `raspotify` doesn't work when built with a current version of `librespot`.