### PR TITLE
Preinst fixes for #300

### DIFF
--- a/raspotify/DEBIAN/preinst
+++ b/raspotify/DEBIAN/preinst
@@ -2,4 +2,6 @@
 
 # Fix changes in command line arguments for librespot v0.1.3
 
-sed -i 's/--linear-volume/--volume-ctrl=linear/' /etc/default/raspotify >/dev/null 2>&1
+if [ -e /etc/default/raspotify ]; then
+    sed -i 's/--linear-volume/--volume-ctrl=linear/' /etc/default/raspotify >/dev/null 2>&1
+fi

--- a/raspotify/DEBIAN/preinst
+++ b/raspotify/DEBIAN/preinst
@@ -2,6 +2,10 @@
 
 # Fix changes in command line arguments for librespot v0.1.3
 
-if [ -e /etc/default/raspotify ]; then
-    sed -i 's/--linear-volume/--volume-ctrl=linear/' /etc/default/raspotify >/dev/null 2>&1
+if [ -f /etc/default/raspotify ]; then
+    sed -i 's/--linear-volume/--volume-ctrl=linear/' /etc/default/raspotify > /dev/null 2>&1
+fi
+
+if [ -f /etc/systemd/system/raspotify.service ]; then
+    sed -i 's/--linear-volume/--volume-ctrl=linear/' /etc/systemd/system/raspotify.service > /dev/null 2>&1
 fi


### PR DESCRIPTION
This fixes sed failing when files don't exist and preventing installation, as well as also editing the systemd service in addition to /etc/default/raspotify.

Discussed in #300.