### PR TITLE
Test for config file existence before patch.

### DIFF
--- a/raspotify/DEBIAN/preinst
+++ b/raspotify/DEBIAN/preinst
@@ -2,4 +2,4 @@
 
 # Fix changes in command line arguments for librespot v0.1.3
 
-sed -i 's/--linear-volume/--volume-ctrl=linear/' /etc/default/raspotify >/dev/null 2>&1
+test -e /etc/default/raspotify && sed -i 's/--linear-volume/--volume-ctrl=linear/' /etc/default/raspotify >/dev/null 2>&1


### PR DESCRIPTION
New installations are currently breaking because the config file
is not installed yet when preinst runs.