### PR TITLE
Add option to change device type

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ which passes arguments to [librespot](https://github.com/librespot-org/librespot
 # Backend could be set to pipe here, but it's for very advanced use cases of
 # librespot, so you shouldn't need to change this under normal circumstances.
 #BACKEND_ARGS="--backend alsa"
+
+# The displayed device type in Spotify clients. 
+# Can be "unknown", "computer", "tablet", "smartphone", "speaker", "tv",
+# "avr" (Audio/Video Receiver), "stb" (Set-Top Box), and "audiodongle".
+#DEVICE_TYPE="speaker"
 ```
 
 After editing restart the daemon by running: `sudo systemctl restart raspotify`

--- a/raspotify/etc/default/raspotify
+++ b/raspotify/etc/default/raspotify
@@ -32,3 +32,8 @@
 # Backend could be set to pipe here, but it's for very advanced use cases of
 # librespot, so you shouldn't need to change this under normal circumstances.
 #BACKEND_ARGS="--backend alsa"
+
+# The displayed device type in Spotify clients. 
+# Can be "unknown", "computer", "tablet", "smartphone", "speaker", "tv",
+# "avr" (Audio/Video Receiver), "stb" (Set-Top Box), and "audiodongle".
+#DEVICE_TYPE="speaker"

--- a/raspotify/lib/systemd/system/raspotify.service
+++ b/raspotify/lib/systemd/system/raspotify.service
@@ -14,8 +14,9 @@ Environment="BITRATE=160"
 Environment="CACHE_ARGS=--disable-audio-cache"
 Environment="VOLUME_ARGS=--enable-volume-normalisation --volume-ctrl=linear --initial-volume=100"
 Environment="BACKEND_ARGS=--backend alsa"
+Environment="DEVICE_TYPE=speaker"
 EnvironmentFile=-/etc/default/raspotify
-ExecStart=/usr/bin/librespot --name ${DEVICE_NAME} $BACKEND_ARGS --bitrate ${BITRATE} $CACHE_ARGS $VOLUME_ARGS $OPTIONS
+ExecStart=/usr/bin/librespot --name ${DEVICE_NAME} $BACKEND_ARGS --bitrate ${BITRATE} $CACHE_ARGS $VOLUME_ARGS $OPTIONS --device-type ${DEVICE_TYPE}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Allows users to edit the device type that is displayed by the Spotify clients. This results in different icons and thus a nicer user experience.

Uses the `--device-type` option supported by librespot.