### PR TITLE
added normalisation-pregain option to config file

### DIFF
--- a/raspotify/etc/default/raspotify
+++ b/raspotify/etc/default/raspotify
@@ -32,7 +32,8 @@
 
 # By default, the volume normalization is enabled, add alternative volume
 # arguments here if you'd like, but these should be fine.
-#VOLUME_ARGS="--enable-volume-normalisation --volume-ctrl linear --initial-volume=100"
+# If you have issues with low default volume, edit the dB value for normalisation pregain.
+#VOLUME_ARGS="--enable-volume-normalisation --normalisation-pregain 0 --volume-ctrl linear --initial-volume=100"
 
 # Backend could be set to pipe here, but it's for very advanced use cases of
 # librespot, so you shouldn't need to change this under normal circumstances.


### PR DESCRIPTION
First of all, thanks for the great repository!

I personally had some issues with low levels of default sound, and saw the additional --normalisation-pregain option in the librespot docs. This PR is quite simple, I've added this to the VOLUME_ARGS. I think this option might help other users quickly to solve issues with low volumes.

This is my first pull-request, so if I submitted this in the wrong way, please forgive me!