### PR TITLE
Modified config file with new instructions for --device

### DIFF
--- a/raspotify/etc/default/raspotify
+++ b/raspotify/etc/default/raspotify
@@ -34,7 +34,7 @@
 # add '--device hw:CARD=b1,DEV=0' to options. Another example using a hardware 
 # DAC would be '--device hw:CARD=IQaudIODAC,DEV=0'
 # This method is useful, as the name wont change depending on which devices are
-# connected to the Pi, as was with the old way (i.e. --device hw:0)
+# connected to the Pi, as was with the old way (i.e. --device hw:0,0)
 # This might not work if you're using a USB sound card, and you'll be stuck to
 # specifying devices like --device hw:0,0
 

--- a/raspotify/etc/default/raspotify
+++ b/raspotify/etc/default/raspotify
@@ -24,7 +24,7 @@
 # librespot --name hello --device ? | grep plughw -v | grep hwdep -v | grep hw
 # This lists available devices (note b1=HDMI1, b2=HDMI2 etc.). 
 # If you can’t find your device with that command, try running:
-# librespot –name hello –device ?
+# librespot --name hello --device ?
 # This gives a more verbose output, which can help you identify the target
 # sound card if it has a weird name
 # Say you want Spotify to play out of HDMI1, you run that command, and copy the 
@@ -35,6 +35,8 @@
 # DAC would be '--device hw:CARD=IQaudIODAC,DEV=0'
 # This method is useful, as the name wont change depending on which devices are
 # connected to the Pi, as was with the old way (i.e. --device hw:0)
+# This might not work if you're using a USB sound card, and you'll be stuck to
+# specifying devices like --device hw:0,0
 
 #OPTIONS="--username <USERNAME> --password <PASSWORD>"
 

--- a/raspotify/etc/default/raspotify
+++ b/raspotify/etc/default/raspotify
@@ -20,9 +20,22 @@
 # username and password which can be set via "Set device password", on your
 # account settings, use `--username` and `--password`.
 #
-# To choose a different output device (ie a USB audio dongle or HDMI audio out),
-# use `--device` with something like `--device hw:0,1`. Your mileage may vary.
-#
+# Available devices can be listed with the following command:
+# librespot --name hello --device ? | grep plughw -v | grep hwdep -v | grep hw
+# This lists available devices (note b1=HDMI1, b2=HDMI2 etc.). 
+# If you can’t find your device with that command, try running:
+# librespot –name hello –device ?
+# This gives a more verbose output, which can help you identify the target
+# sound card if it has a weird name
+# Say you want Spotify to play out of HDMI1, you run that command, and copy the 
+# entire line b1 then you add '--device ' with your preferred device to 
+# the OPTIONS field below. For example, you want to set Spotify to output out of 
+# HDMI1 you run the command, copy the line 'hw:CARD=b1,DEV=0' from the output and 
+# add '--device hw:CARD=b1,DEV=0' to options. Another example using a hardware 
+# DAC would be '--device hw:CARD=IQaudIODAC,DEV=0'
+# This method is useful, as the name wont change depending on which devices are
+# connected to the Pi, as was with the old way (i.e. --device hw:0)
+
 #OPTIONS="--username <USERNAME> --password <PASSWORD>"
 
 # Uncomment to use a cache for downloaded audio files. Cache is disabled by


### PR DESCRIPTION
TLDR : Updated config comments to provide a better way to select --device for passing through to librespot, and a one liner to show available options.

I was having trouble that every time i plugged in a HDMI into HDMI2, the alsa hw allocation would change for my DAC (from hw:2 to hw:3) on raspi4. This meant no audio would come out, and it would require a config change. To solve this rather than using hw:2,hw:3 etc. I'm using hw:CARD=IQaudIODAC,DEV=0. I have also provided a oneliner to extract the correct --device options for use with raspotify
