### PR TITLE
update deprecated argument usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ RestartSec=10
 Environment="DEVICE_NAME=raspotify (%H)"                                                               
 Environment="BITRATE=160"
 Environment="CACHE_ARGS=--disable-audio-cache"
-Environment="VOLUME_ARGS=--enable-volume-normalisation --linear-volume --initial-volume=100"
+Environment="VOLUME_ARGS=--enable-volume-normalisation --volume-ctrl linear --initial-volume=100"
 Environment="BACKEND_ARGS=--backend alsa"
 EnvironmentFile=-/etc/default/raspotify
 ExecStart=/usr/bin/librespot --name ${DEVICE_NAME} $BACKEND_ARGS --bitrate ${BITRATE} $CACHE_ARGS $VOLUME_ARGS $OPTIONS


### PR DESCRIPTION
Not sure if librespot deprecated the usage of --linear-volume or if it never existed however running librespot with the following arguments:

`/usr/bin/librespot --name raspi --backend alsa --bitrate 160 --disable-audio-cache --enable-volume-normalisation --linear-volume --initial-volume=100 --username {user_id} --password {password}`

 will throw the error:

```
error: Unrecognized option: 'linear-volume'
Usage: /usr/bin/librespot [options]
```

"--linear-volume" argument should be replaced by "--volume-ctrl linear"

e.g:

`/usr/bin/librespot --name raspi --backend alsa --bitrate 160 --disable-audio-cache --enable-volume-normalisation --volume-ctrl linear --initial-volume=100 --username {user_id} --password {password}`