### PR TITLE
Fix version of unidecode for Python 2.7 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
 
 RUN pip install \
         jinja2-cli  \
-        unidecode
+        unidecode==1.2.0
 
 RUN mkdir /toolchain
 WORKDIR /toolchain


### PR DESCRIPTION
Unidecode dropped support for Python < 3.5 in version 1.3.0