### PR TITLE
apt-key is deprecated - This patch uses the more secure [signed-by]

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,12 @@ Essentially, here's what the easy installer does,
 # Install curl and https apt transport
 sudo apt-get -y install curl apt-transport-https
 
-# Add repo and its GPG key
-curl -sSL https://dtcooper.github.io/raspotify/key.asc | sudo apt-key add -v -
-echo 'deb https://dtcooper.github.io/raspotify raspotify main' | sudo tee /etc/apt/sources.list.d/raspotify.list
+# Add the raspotify key to the keyring
+curl -sSL https://dtcooper.github.io/raspotify/key.asc | sudo tee /usr/share/keyrings/raspotify_key.asc  > /dev/null
+sudo chmod 644 /usr/share/keyrings/raspotify_key.asc
+
+# Create the apt repo
+echo 'deb [signed-by=/usr/share/keyrings/raspotify_key.asc] https://dtcooper.github.io/raspotify raspotify main' | sudo tee /etc/apt/sources.list.d/raspotify.list
 
 # Install package
 sudo apt-get update

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-SOURCE_REPO="deb https://dtcooper.github.io/raspotify raspotify main"
+SOURCE_REPO="deb [signed-by=/usr/share/keyrings/raspotify_key.asc] https://dtcooper.github.io/raspotify raspotify main"
 
 # Install script for Raspotify. Adds the Debian repo and installs.
 set -e
@@ -34,7 +34,8 @@ if uname -a | fgrep -ivq arm; then
 fi
 
 # Add public key to apt
-curl -sSL https://dtcooper.github.io/raspotify/key.asc | sudo apt-key add -v -
+curl -sSL https://dtcooper.github.io/raspotify/key.asc | sudo tee /usr/share/keyrings/raspotify_key.asc  > /dev/null
+sudo chmod 644 /usr/share/keyrings/raspotify_key.asc
 echo "$SOURCE_REPO" | sudo tee /etc/apt/sources.list.d/raspotify.list
 
 sudo apt-get update


### PR DESCRIPTION
apt-key has been deprecated and will not work in later versions of debian/ubuntu.

Solution:
If you put the key in a separate file (/usr/share/keyrings/raspotify_key.asc) and change /etc/apt/sources.list.d/raspotify.list to:
`deb [signed-by=/usr/share/keyrings/raspotify_key.asc] https://dtcooper.github.io/raspotify raspotify main
`
It makes only that key able to sign raspotify deb packages and it does not let the key sign any other packages.

This patch changes the install.sh to use the signed-by syntax and updates the README.md

REFS:
https://askubuntu.com/questions/1286545/what-commands-exactly-should-replace-the-deprecated-apt-key
https://www.techrepublic.com/article/how-to-add-an-openpgp-repository-key-now-that-apt-key-is-deprecated/
 