### PR TITLE
Security harden Raspotify

### DIFF
--- a/raspotify/DEBIAN/postinst
+++ b/raspotify/DEBIAN/postinst
@@ -9,12 +9,10 @@ fi
 
 if ! id raspotify >/dev/null 2>&1; then
     adduser --system --disabled-password --disabled-login \
-        --home /var/cache/raspotify --ingroup raspotify raspotify
-fi
+        --no-create-home --ingroup raspotify raspotify
 
-mkdir -m 0755 -p /var/cache/raspotify
-chown raspotify:raspotify /var/cache/raspotify
-adduser raspotify audio
+    adduser raspotify audio
+fi
 
 # Make sure `--linear-volume' is properly renamed
 if [ -f /etc/default/raspotify ]; then

--- a/raspotify/lib/systemd/system/raspotify.service
+++ b/raspotify/lib/systemd/system/raspotify.service
@@ -1,21 +1,74 @@
 [Unit]
-Description=Raspotify
+Description=Raspotify (Spotify Connect Client)
+Documentation=https://github.com/dtcooper/raspotify
+Documentation=https://github.com/librespot-org/librespot
+Documentation=https://github.com/dtcooper/raspotify/wiki
+Documentation=https://github.com/librespot-org/librespot/wiki/Options
+Requires=network.target
 After=network.target
+Requires=sound.target
+After=sound.target
 
 [Service]
 User=raspotify
 Group=raspotify
+
 Restart=always
 RestartSec=10
+
+RestrictRealtime=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK
+
+ProtectHostname=true
+ProtectControlGroups=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProtectHome=true
+ProtectSystem=strict
+ProtectClock=yes
+
+DevicePolicy=strict
+
+DeviceAllow=char-alsa rw
+DeviceAllow=/dev/null r
+DeviceAllow=/dev/random r
+DeviceAllow=/dev/urandom r
+
+UMask=077
+CacheDirectory=raspotify
+ReadWritePaths=/var/cache/raspotify
+
+PrivateTmp=true
+PrivateUsers=true
+
+ProcSubset=pid
+NoNewPrivileges=true
 PermissionsStartOnly=true
-ExecStartPre=/bin/mkdir -m 0755 -p /var/cache/raspotify ; /bin/chown raspotify:raspotify /var/cache/raspotify
-Environment="DEVICE_NAME=raspotify (%H)"
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RemoveIPC=true
+
+CapabilityBoundingSet=
+
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+SystemCallErrorNumber=EPERM
+
+Environment="DEVICE_NAME=Raspotify (%H)"
 Environment="BITRATE=160"
 Environment="CACHE_ARGS=--disable-audio-cache"
 Environment="VOLUME_ARGS=--enable-volume-normalisation --volume-ctrl linear --initial-volume 100"
 Environment="BACKEND_ARGS=--backend alsa"
 Environment="DEVICE_TYPE=speaker"
+
+ConfigurationDirectory=default
 EnvironmentFile=-/etc/default/raspotify
+
 ExecStart=/usr/bin/librespot --name ${DEVICE_NAME} --device-type ${DEVICE_TYPE} $BACKEND_ARGS --bitrate ${BITRATE} $CACHE_ARGS $VOLUME_ARGS $OPTIONS
 
 [Install]


### PR DESCRIPTION
* Sandbox the Raspotify service as much as possible.
* Let systemd take care of creating the cache folder with `CacheDirectory=raspotify` this also allows the user to empty the cache folder with `sudo systemctl clean raspotify` (provided raspotify is not currently running).
* Use `UMask=077` So that all cache files are written with 0600 permissions so no other user can read them.
* Added `After` and `Requires` `sound.target` because we want Raspotify to start after we have a sound device.
* Added `Documentation` fields.
* Amended `Description`.
* There's no reason that the `raspotify` user needs a home folder.

These changes will not affect existing users as the systemd unit file is not over written on update. If existing user wish to opt into these changes they should use `sudo systemctl edit --full raspotify` to edit the raspotify service unit file.

I'm putting this in a PR to get feedback in case I missed anything.