### PR TITLE
Remove line from security hardening that causes librespot to not start

### DIFF
--- a/raspotify/lib/systemd/system/raspotify.service
+++ b/raspotify/lib/systemd/system/raspotify.service
@@ -54,7 +54,6 @@ RemoveIPC=true
 
 CapabilityBoundingSet=
 
-SystemCallArchitectures=native
 SystemCallFilter=@system-service
 SystemCallFilter=~@privileged @resources
 SystemCallErrorNumber=EPERM


### PR DESCRIPTION
See #451 