### PR TITLE
Fix a bug that prevents ALSA from initializing

### DIFF
--- a/raspotify/lib/systemd/system/raspotify.service
+++ b/raspotify/lib/systemd/system/raspotify.service
@@ -32,7 +32,7 @@ ProtectClock=yes
 
 DevicePolicy=strict
 DeviceAllow=char-alsa rw
-DeviceAllow=/dev/null r
+DeviceAllow=/dev/null rw
 DeviceAllow=/dev/random r
 DeviceAllow=/dev/urandom r
 


### PR DESCRIPTION
In some configurations, ALSA needs to be able to write to /dev/null in order to work. Without it, I get this error message:

raspberrypi librespot[9307]: ALSA lib pcm_null.c:387:(snd_pcm_null_open) Cannot open /dev/null: Operation not permitted
raspberrypi librespot[9307]: [2022-03-23T02:45:05Z ERROR librespot_playback::player] Audio Sink Error Connection Refused: <AlsaSink> Device default May be Invalid, Busy, or Already in Use, ALSA function 'snd_pcm_open' failed with error 'EPERM: Operation not permitted'
raspberrypi systemd[1]: raspotify.service: Main process exited, code=exited, status=1/FAILURE
raspberrypi systemd[1]: raspotify.service: Failed with result 'exit-code'.