### PR TITLE
Compile against upstream librespot.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN mkdir /build \
     && echo '[target.aarch64-unknown-linux-gnu]\nlinker = "aarch64-linux-gnu-gcc"' > /.cargo/config \
     && echo '[target.armv7-unknown-linux-gnueabihf]\nlinker = "arm-linux-gnueabihf-gcc"' >> /.cargo/config \
     && cargo install --jobs "$(nproc)" cargo-deb \
-    && dpkg --add-architecture arm64 \
+    ;
+
+RUN dpkg --add-architecture arm64 \
     && dpkg --add-architecture armhf \
     && apt-get update \
     && apt-get -y upgrade \
@@ -31,6 +33,8 @@ RUN mkdir /build \
         crossbuild-essential-armhf \
         libasound2-dev:armhf \
         libpulse-dev:armhf \
+        cmake \
+        clang-16 \
         git \
         bc \
         dpkg-dev \
@@ -38,4 +42,9 @@ RUN mkdir /build \
         pkg-config \
         gettext-base \
     && rm -rf /var/lib/apt/lists/* \
-    && git config --global --add safe.directory /mnt/raspotify
+    ;
+
+RUN cargo install --force --locked --root /usr bindgen-cli
+
+RUN git config --global --add safe.directory /mnt/raspotify \
+    && git config --global --add safe.directory /mnt/raspotify/librespot

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ MIT License
 
 Copyright (c) 2017-2023, David Cooper <david@dtcooper.com>
 Copyright (c) 2021-2023, Jason Gray <jasonlevigray3@gmail.com>
+Copyright (c) 2024, Kim Tore Jensen <kimtjen@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all armhf arm64 amd64 clean distclean
 .DEFAULT_GOAL := all
 
-RASPOTIFY_AUTHOR?=Jason Gray <jasonlevigray3@gmail.com>
+RASPOTIFY_AUTHOR?=Kim Tore Jensen <kimtjen@gmail.com>
 
 armhf:
 	docker build -t raspotify .

--- a/build.sh
+++ b/build.sh
@@ -39,11 +39,7 @@ packages() {
 	if [ ! -d librespot ]; then
 		echo "Get https://github.com/librespot-org/librespot/tree/dev..."
 		git clone --branch dev https://github.com/librespot-org/librespot
-		cd /mnt/raspotify
 	fi
-
-	# Quelch warning about dubious ownership
-	git config --global --add safe.directory /mnt/raspotify/librespot
 
 	DOC_DIR="raspotify/usr/share/doc/raspotify"
 
@@ -66,7 +62,7 @@ packages() {
 	# time we update against librespot.
 	#
 	#LIBRESPOT_VER="$(git describe --tags "$(git rev-list --tags --max-count=1)" 2>/dev/null || echo unknown)"
-	LIBRESPOT_VER=0.5.0-dev
+	LIBRESPOT_VER=v0.5.0-dev
 	LIBRESPOT_HASH="$(git rev-parse HEAD | cut -c 1-7 2>/dev/null || echo unknown)"
 
 	echo "Build Librespot binary..."

--- a/build.sh
+++ b/build.sh
@@ -182,8 +182,8 @@ case $ARCHITECTURE in
 	;;
 esac
 
-# Perm fixup. Not needed on macOS, but is on Linux
-chown -R "$PERMFIX_UID:$PERMFIX_GID" /mnt/raspotify 2>/dev/null || true
+# Fix broken permissions resulting from running the Docker container as root.
+[ $(id -u) -eq 0 ] && chown -R "$PERMFIX_UID:$PERMFIX_GID" /mnt/raspotify 2>/dev/null
 
 BUILD_TIME=$(duration_since "$START_BUILDS")
 


### PR DESCRIPTION
This patch uses upstream dev branch in favor of Jason's fork.

~The dev branch merged cleanly into that fork, and there was no diff between the two trees.~

The commit trees for the fork and upstream diverge. Many commits won't merge because of conflicts. Some code seems similar on both sides. I have no idea about the potential breakage for downstream users, but the alternative is to leave it unmaintained. Hopefully everything works fine :-)

Fixes #670
Fixes #669