### PR TITLE
ci: add riscv64 support and packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,8 @@ RUN mkdir /build \
     && mkdir /.cargo \
     && rustup target add aarch64-unknown-linux-gnu \
     && rustup target add armv7-unknown-linux-gnueabihf \
-    && rustup target add riscv64gc-unknown-linux-gnu \
     && echo '[target.aarch64-unknown-linux-gnu]\nlinker = "aarch64-linux-gnu-gcc"' > /.cargo/config \
     && echo '[target.armv7-unknown-linux-gnueabihf]\nlinker = "arm-linux-gnueabihf-gcc"' >> /.cargo/config \
-    && echo '[target.riscv64gc-unknown-linux-gnu ]\nlinker = "riscv64-linux-gnu-gcc"' >> /.cargo/config \
     && cargo install --jobs "$(nproc)" cargo-deb \
     ;
 
@@ -36,8 +34,6 @@ RUN dpkg --add-architecture arm64 \
         crossbuild-essential-armhf \
         libasound2-dev:armhf \
         libpulse-dev:armhf \
-        gcc-riscv64-linux-gnu \
-        g++-riscv64-linux-gnu \
         cmake \
         clang-16 \
         git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,20 +4,10 @@ ENV INSIDE_DOCKER_CONTAINER=1 \
     DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NOWARNINGS=yes \
     PKG_CONFIG_ALLOW_CROSS=1 \
-    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabihf/pkgconfig" \
     PATH="/root/.cargo/bin/:$PATH" \
     CARGO_INSTALL_ROOT="/root/.cargo" \
     CARGO_TARGET_DIR="/build" \
     CARGO_HOME="/build/cache"
-
-RUN mkdir /build \
-    && mkdir /.cargo \
-    && rustup target add aarch64-unknown-linux-gnu \
-    && rustup target add armv7-unknown-linux-gnueabihf \
-    && echo '[target.aarch64-unknown-linux-gnu]\nlinker = "aarch64-linux-gnu-gcc"' > /.cargo/config \
-    && echo '[target.armv7-unknown-linux-gnueabihf]\nlinker = "arm-linux-gnueabihf-gcc"' >> /.cargo/config \
-    && cargo install --jobs "$(nproc)" cargo-deb \
-    ;
 
 RUN dpkg --add-architecture arm64 \
     && dpkg --add-architecture armhf \
@@ -26,7 +16,6 @@ RUN dpkg --add-architecture arm64 \
     && apt-get install -y --no-install-recommends \
         build-essential \
         libasound2-dev \
-        libavahi-client-dev \
         libpulse-dev \
         crossbuild-essential-arm64 \
         libasound2-dev:arm64 \
@@ -38,14 +27,20 @@ RUN dpkg --add-architecture arm64 \
         clang-16 \
         git \
         bc \
-        dpkg-dev \
         liblzma-dev \
         pkg-config \
         gettext-base \
     && rm -rf /var/lib/apt/lists/* \
     ;
 
-RUN cargo install --force --locked --root /usr bindgen-cli
+RUN mkdir /build /.cargo \
+    && rustup target add aarch64-unknown-linux-gnu \
+    && rustup target add armv7-unknown-linux-gnueabihf \
+    && echo '[target.aarch64-unknown-linux-gnu]\nlinker = "aarch64-linux-gnu-gcc"' > /.cargo/config.toml \
+    && echo '[target.armv7-unknown-linux-gnueabihf]\nlinker = "arm-linux-gnueabihf-gcc"' >> /.cargo/config.toml \
+    && cargo install --jobs "$(nproc)" cargo-deb \
+    && cargo install --force --locked --root /usr bindgen-cli \
+    ;
 
 RUN git config --global --add safe.directory /mnt/raspotify \
     && git config --global --add safe.directory /mnt/raspotify/librespot

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@ RUN mkdir /build \
     && mkdir /.cargo \
     && rustup target add aarch64-unknown-linux-gnu \
     && rustup target add armv7-unknown-linux-gnueabihf \
+    && rustup target add riscv64gc-unknown-linux-gnu \
     && echo '[target.aarch64-unknown-linux-gnu]\nlinker = "aarch64-linux-gnu-gcc"' > /.cargo/config \
     && echo '[target.armv7-unknown-linux-gnueabihf]\nlinker = "arm-linux-gnueabihf-gcc"' >> /.cargo/config \
+    && echo '[target.riscv64gc-unknown-linux-gnu ]\nlinker = "riscv64-linux-gnu-gcc"' >> /.cargo/config \
     && cargo install --jobs "$(nproc)" cargo-deb \
     ;
 
@@ -34,6 +36,8 @@ RUN dpkg --add-architecture arm64 \
         crossbuild-essential-armhf \
         libasound2-dev:armhf \
         libpulse-dev:armhf \
+        gcc-riscv64-linux-gnu \
+        g++-riscv64-linux-gnu \
         cmake \
         clang-16 \
         git \

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -1,41 +1,15 @@
-# Upper part taken from https://github.com/rust-lang/docker-rust/blob/master/stable/bookworm/Dockerfile
-# since there are no rust-trixie Docker images yet
+# Dedicated riscv64 trixie Dockerfile, until official rust:trixie images are available:
+# https://github.com/rust-lang/docker-rust/blob/master/stable/
 FROM buildpack-deps:trixie
-
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.83.0
-
-RUN set -eux; \
-    rustArch='x86_64-unknown-linux-gnu'; rustupSha256='6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d'; \
-    url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init"; \
-    wget "$url"; \
-    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
-    chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
-    rm rustup-init; \
-    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
-    rustup --version; \
-    cargo --version; \
-    rustc --version;
 
 ENV INSIDE_DOCKER_CONTAINER=1 \
     DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NOWARNINGS=yes \
     PKG_CONFIG_ALLOW_CROSS=1 \
-    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabihf/pkgconfig" \
     PATH="/root/.cargo/bin/:$PATH" \
     CARGO_INSTALL_ROOT="/root/.cargo" \
     CARGO_TARGET_DIR="/build" \
     CARGO_HOME="/build/cache"
-
-RUN mkdir /build \
-    && mkdir /.cargo \
-    && rustup target add riscv64gc-unknown-linux-gnu \
-    && echo '[target.riscv64gc-unknown-linux-gnu ]\nlinker = "riscv64-linux-gnu-gcc"' >> /.cargo/config \
-    && cargo install --jobs "$(nproc)" cargo-deb \
-    ;
 
 RUN dpkg --add-architecture riscv64 \
     && apt-get update \
@@ -43,7 +17,6 @@ RUN dpkg --add-architecture riscv64 \
     && apt-get install -y --no-install-recommends \
         build-essential \
         libasound2-dev \
-        libavahi-client-dev \
         libpulse-dev \
         crossbuild-essential-riscv64 \
         libasound2-dev:riscv64 \
@@ -52,14 +25,19 @@ RUN dpkg --add-architecture riscv64 \
         clang-19 \
         git \
         bc \
-        dpkg-dev \
         liblzma-dev \
         pkg-config \
         gettext-base \
+	rustup \
     && rm -rf /var/lib/apt/lists/* \
     ;
 
-RUN cargo install --force --locked --root /usr bindgen-cli
+RUN mkdir /build /.cargo \
+    && rustup toolchain install stable --profile minimal --target riscv64gc-unknown-linux-gnu \
+    && echo '[target.riscv64gc-unknown-linux-gnu ]\nlinker = "riscv64-linux-gnu-gcc"' > /.cargo/config.toml \
+    && cargo install --jobs "$(nproc)" cargo-deb \
+    && cargo install --force --locked --root /usr bindgen-cli \
+    ;
 
 RUN git config --global --add safe.directory /mnt/raspotify \
     && git config --global --add safe.directory /mnt/raspotify/librespot

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -1,0 +1,65 @@
+# Upper part taken from https://github.com/rust-lang/docker-rust/blob/master/stable/bookworm/Dockerfile
+# since there are no rust-trixie Docker images yet
+FROM buildpack-deps:trixie
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.83.0
+
+RUN set -eux; \
+    rustArch='x86_64-unknown-linux-gnu'; rustupSha256='6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d'; \
+    url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+
+ENV INSIDE_DOCKER_CONTAINER=1 \
+    DEBIAN_FRONTEND=noninteractive \
+    DEBCONF_NOWARNINGS=yes \
+    PKG_CONFIG_ALLOW_CROSS=1 \
+    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabihf/pkgconfig" \
+    PATH="/root/.cargo/bin/:$PATH" \
+    CARGO_INSTALL_ROOT="/root/.cargo" \
+    CARGO_TARGET_DIR="/build" \
+    CARGO_HOME="/build/cache"
+
+RUN mkdir /build \
+    && mkdir /.cargo \
+    && rustup target add riscv64gc-unknown-linux-gnu \
+    && echo '[target.riscv64gc-unknown-linux-gnu ]\nlinker = "riscv64-linux-gnu-gcc"' >> /.cargo/config \
+    && cargo install --jobs "$(nproc)" cargo-deb \
+    ;
+
+RUN dpkg --add-architecture riscv64 \
+    && apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libasound2-dev \
+        libavahi-client-dev \
+        libpulse-dev \
+        crossbuild-essential-riscv64 \
+        libasound2-dev:riscv64 \
+        libpulse-dev:riscv64 \
+        cmake \
+        clang-19 \
+        git \
+        bc \
+        dpkg-dev \
+        liblzma-dev \
+        pkg-config \
+        gettext-base \
+    && rm -rf /var/lib/apt/lists/* \
+    ;
+
+RUN cargo install --force --locked --root /usr bindgen-cli
+
+RUN git config --global --add safe.directory /mnt/raspotify \
+    && git config --global --add safe.directory /mnt/raspotify/librespot

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all armhf arm64 amd64 clean distclean
+.PHONY: all armhf arm64 amd64 riscv64 clean distclean
 .DEFAULT_GOAL := all
 
 RASPOTIFY_AUTHOR?=Kim Tore Jensen <kimtjen@gmail.com>
@@ -34,6 +34,17 @@ amd64:
 			--env PERMFIX_GID="$$(id -g)" \
 			--env RASPOTIFY_AUTHOR="$(RASPOTIFY_AUTHOR)" \
 			--env ARCHITECTURE="amd64" \
+		raspotify /mnt/raspotify/build.sh
+
+riscv64:
+	docker build -t raspotify .
+	docker run \
+			--rm \
+			--volume "$(CURDIR):/mnt/raspotify" \
+			--env PERMFIX_UID="$$(id -u)" \
+			--env PERMFIX_GID="$$(id -g)" \
+			--env RASPOTIFY_AUTHOR="$(RASPOTIFY_AUTHOR)" \
+			--env ARCHITECTURE="riscv64" \
 		raspotify /mnt/raspotify/build.sh
 
 all:

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ amd64:
 		raspotify /mnt/raspotify/build.sh
 
 riscv64:
-	docker build -t raspotify .
+	docker build -t raspotify -f Dockerfile.riscv64 .
 	docker run \
 			--rm \
 			--volume "$(CURDIR):/mnt/raspotify" \
@@ -47,7 +47,7 @@ riscv64:
 			--env ARCHITECTURE="riscv64" \
 		raspotify /mnt/raspotify/build.sh
 
-all:
+all: riscv64 distclean
 	docker build -t raspotify .
 	docker run \
 			--rm \

--- a/build.sh
+++ b/build.sh
@@ -150,7 +150,6 @@ build_all() {
 	build_armhf
 	build_arm64
 	build_amd64
-	build_riscv64
 }
 
 START_BUILDS=$(now)

--- a/build.sh
+++ b/build.sh
@@ -140,10 +140,17 @@ build_amd64() {
 	packages
 }
 
+build_riscv64() {
+	ARCHITECTURE="riscv64"
+	BUILD_TARGET="riscv64gc-unknown-linux-gnu"
+	packages
+}
+
 build_all() {
 	build_armhf
 	build_arm64
 	build_amd64
+	build_riscv64
 }
 
 START_BUILDS=$(now)
@@ -165,6 +172,9 @@ case $ARCHITECTURE in
 	;;
 "amd64")
 	build_amd64
+	;;
+"riscv64")
+	build_riscv64
 	;;
 "all")
 	build_all

--- a/deploy-apt-repo.sh
+++ b/deploy-apt-repo.sh
@@ -38,6 +38,11 @@ if [ $(ls -1 raspotify*_amd64.deb | wc -l) -ne 1 ]; then
     exit 1
 fi
 
+if [ $(ls -1 raspotify*_riscv64.deb | wc -l) -ne 1 ]; then
+    echo 'Exactly one raspotify*_riscv64.deb package needs to be in folder.'
+    exit 1
+fi
+
 if [ $(ls -1 asound-conf-wizard*_armhf.deb | wc -l) -ne 1 ]; then
     echo 'Exactly one asound-conf-wizard*_armhf.deb package needs to be in folder.'
     exit 1
@@ -53,6 +58,11 @@ if [ $(ls -1 asound-conf-wizard*_amd64.deb | wc -l) -ne 1 ]; then
     exit 1
 fi
 
+if [ $(ls -1 asound-conf-wizard*_riscv64.deb | wc -l) -ne 1 ]; then
+    echo 'Exactly one asound-conf-wizard*_riscv64.deb package needs to be in folder.'
+    exit 1
+fi
+
 RASPOTIFY_ARMHF_DEB_PKG_NAME="$(ls -1 raspotify*_armhf.deb | head -n 1)"
 echo "Using package: $RASPOTIFY_ARMHF_DEB_PKG_NAME"
 
@@ -62,6 +72,9 @@ echo "Using package: $RASPOTIFY_ARM64_DEB_PKG_NAME"
 RASPOTIFY_AMD64_DEB_PKG_NAME="$(ls -1 raspotify*_amd64.deb | head -n 1)"
 echo "Using package: $RASPOTIFY_AMD64_DEB_PKG_NAME"
 
+RASPOTIFY_RISCV64_DEB_PKG_NAME="$(ls -1 raspotify*_riscv64.deb | head -n 1)"
+echo "Using package: $RASPOTIFY_RISCV64_DEB_PKG_NAME"
+
 AWIZ_ARMHF_DEB_PKG_NAME="$(ls -1 asound-conf-wizard*_armhf.deb | head -n 1)"
 echo "Using package: $AWIZ_ARMHF_DEB_PKG_NAME"
 
@@ -70,6 +83,9 @@ echo "Using package: $AWIZ_ARM64_DEB_PKG_NAME"
 
 AWIZ_AMD64_DEB_PKG_NAME="$(ls -1 asound-conf-wizard*_amd64.deb | head -n 1)"
 echo "Using package: $AWIZ_AMD64_DEB_PKG_NAME"
+
+AWIZ_RISCV64_DEB_PKG_NAME="$(ls -1 asound-conf-wizard*_riscv64.deb | head -n 1)"
+echo "Using package: $AWIZ_RISCV64_DEB_PKG_NAME"
 
 echo "Importing gpg key"
 echo "$GPG_SECRET_KEY_BASE64" | base64 -d | gpg --import
@@ -83,28 +99,32 @@ mkdir conf
 cat <<EOF > conf/distributions
 Codename: raspotify
 Components: main
-Architectures: armhf arm64 amd64
+Architectures: armhf arm64 amd64 riscv64
 SignWith: $GPG_KEY_ID
 EOF
 
 reprepro includedeb raspotify "../$RASPOTIFY_ARMHF_DEB_PKG_NAME"
 reprepro includedeb raspotify "../$RASPOTIFY_ARM64_DEB_PKG_NAME"
 reprepro includedeb raspotify "../$RASPOTIFY_AMD64_DEB_PKG_NAME"
+reprepro includedeb raspotify "../$RASPOTIFY_RISCV64_DEB_PKG_NAME"
 reprepro includedeb raspotify "../$AWIZ_ARMHF_DEB_PKG_NAME"
 reprepro includedeb raspotify "../$AWIZ_ARM64_DEB_PKG_NAME"
 reprepro includedeb raspotify "../$AWIZ_AMD64_DEB_PKG_NAME"
+reprepro includedeb raspotify "../$AWIZ_RISCV64_DEB_PKG_NAME"
 rm -rf conf db
 
 ln -fs "$(find . -name 'raspotify*_armhf.deb' -type f -printf '%P\n' -quit)" raspotify-latest_armhf.deb
 ln -fs "$(find . -name 'raspotify*_arm64.deb' -type f -printf '%P\n' -quit)" raspotify-latest_arm64.deb
 ln -fs "$(find . -name 'raspotify*_amd64.deb' -type f -printf '%P\n' -quit)" raspotify-latest_amd64.deb
+ln -fs "$(find . -name 'raspotify*_riscv64.deb' -type f -printf '%P\n' -quit)" raspotify-latest_riscv64.deb
 ln -fs "$(find . -name 'asound-conf-wizard*_armhf.deb' -type f -printf '%P\n' -quit)" asound-conf-wizard-latest_armhf.deb
 ln -fs "$(find . -name 'asound-conf-wizard*_arm64.deb' -type f -printf '%P\n' -quit)" asound-conf-wizard-latest_arm64.deb
 ln -fs "$(find . -name 'asound-conf-wizard*_amd64.deb' -type f -printf '%P\n' -quit)" asound-conf-wizard-latest_amd64.deb
+ln -fs "$(find . -name 'asound-conf-wizard*_riscv64.deb' -type f -printf '%P\n' -quit)" asound-conf-wizard-latest_riscv64.deb
 
 echo "Repo created in directory apt-repo with packages:"
-echo "$RASPOTIFY_ARMHF_DEB_PKG_NAME, $RASPOTIFY_ARM64_DEB_PKG_NAME, $RASPOTIFY_AMD64_DEB_PKG_NAME,"
-echo "$AWIZ_ARMHF_DEB_PKG_NAME, $AWIZ_ARM64_DEB_PKG_NAME, and $AWIZ_AMD64_DEB_PKG_NAME."
+echo "$RASPOTIFY_ARMHF_DEB_PKG_NAME, $RASPOTIFY_ARM64_DEB_PKG_NAME, $RASPOTIFY_AMD64_DEB_PKG_NAME, $RASPOTIFY_RISCV64_DEB_PKG_NAME"
+echo "$AWIZ_ARMHF_DEB_PKG_NAME, $AWIZ_ARM64_DEB_PKG_NAME, $AWIZ_AMD64_DEB_PKG_NAME, and $AWIZ_RISCV64_DEB_PKG_NAME."
 
 gpg --armor --export "$GPG_KEY_ID" > key.asc
 cp -v ../README.md ../LICENSE ../install.sh .


### PR DESCRIPTION
This commit adds support for riscv64 (natively supported by cargo) packages to the build script, and adds them to the APT repository deploy script.