### PR TITLE
ci: add simple build test workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  target-branch: "master"
+  labels:
+  - "enhancement"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,19 @@
+name: Build test
+on: [pull_request, push, workflow_dispatch]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  build:
+    strategy:
+      matrix:
+        arch: [armhf, arm64, amd64, riscv64]
+      fail-fast: false
+    name: Build on ${{ matrix.arch }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - run: make ${{ matrix.arch }}

--- a/build.sh
+++ b/build.sh
@@ -160,20 +160,12 @@ cd /mnt/raspotify
 echo 'Obtaining latest Git repository tag for DEB package version ...'
 RASPOTIFY_GIT_VER="$(git describe --tags "$(git rev-list --tags --max-count=1)" || :)"
 if [ -z "$RASPOTIFY_GIT_VER" ]; then
-	# Derive from origin URL whether this is dtcooper/raspotify and hence supposed to have tags.
-	# If so, exit right here, else get tags from dtcooper/raspotify via GitHub API, since forks often do not have any tags.
-	url="$(git remote get-url origin || :)"
-	if [ "$url" = 'https://github.com/dtcooper/raspotify' ] || [ "$url" = 'https://github.com/dtcooper/raspotify/' ] || [ "$url" = 'https://github.com/dtcooper/raspotify.git' ]; then
-		echo 'E: Could not obtain any tag. Exiting ...'
-		exit 1
-	else
-		echo 'W: Could not obtain latest tag from local repository. Obtaining it from upstream: https://api.github.com/repos/dtcooper/raspotify/tags'
-		RASPOTIFY_GIT_VER="$(curl -sSf  "https://api.github.com/repos/dtcooper/raspotify/tags" | awk -F\" '/^ *"name": "/{print $4;exit}' || :)"
-		if [ -z "$RASPOTIFY_GIT_VER" ]; then
-			echo 'E: Could not obtain latest tag from upstream repository either. Exiting ...'
-			exit 1
-		fi
-	fi
+	echo 'Could not obtain latest tag from local repository. Obtaining it from upstream: https://api.github.com/repos/dtcooper/raspotify/tags'
+	RASPOTIFY_GIT_VER="$(curl -sSf  "https://api.github.com/repos/dtcooper/raspotify/tags" | awk -F\" '/^ *"name": "/{print $4;exit}' || :)"
+fi
+if [ -z "$RASPOTIFY_GIT_VER" ]; then
+	echo 'Could not obtain latest tag from upstream repository either. Exiting ...'
+	exit 1
 fi
 RASPOTIFY_HASH="$(git rev-parse HEAD | cut -c 1-7 || echo unknown)"
 

--- a/build.sh
+++ b/build.sh
@@ -160,11 +160,11 @@ cd /mnt/raspotify
 echo 'Obtaining latest Git repository tag for DEB package version ...'
 RASPOTIFY_GIT_VER="$(git describe --tags "$(git rev-list --tags --max-count=1)" || :)"
 if [ -z "$RASPOTIFY_GIT_VER" ]; then
-	echo 'Could not obtain latest tag from local repository. Obtaining it from upstream: https://api.github.com/repos/dtcooper/raspotify/tags'
+	echo 'W: Could not obtain latest tag from local repository. Obtaining it from upstream: https://api.github.com/repos/dtcooper/raspotify/tags'
 	RASPOTIFY_GIT_VER="$(curl -sSf  "https://api.github.com/repos/dtcooper/raspotify/tags" | awk -F\" '/^ *"name": "/{print $4;exit}' || :)"
 fi
 if [ -z "$RASPOTIFY_GIT_VER" ]; then
-	echo 'Could not obtain latest tag from upstream repository either. Exiting ...'
+	echo 'E: Could not obtain latest tag from upstream repository either. Exiting ...'
 	exit 1
 fi
 RASPOTIFY_HASH="$(git rev-parse HEAD | cut -c 1-7 || echo unknown)"

--- a/build.sh
+++ b/build.sh
@@ -160,12 +160,20 @@ cd /mnt/raspotify
 echo 'Obtaining latest Git repository tag for DEB package version ...'
 RASPOTIFY_GIT_VER="$(git describe --tags "$(git rev-list --tags --max-count=1)" || :)"
 if [ -z "$RASPOTIFY_GIT_VER" ]; then
-	echo 'Could not obtain latest tag from local repository. Obtaining it from upstream: https://api.github.com/repos/dtcooper/raspotify/tags'
-	RASPOTIFY_GIT_VER="$(curl -sSf  "https://api.github.com/repos/dtcooper/raspotify/tags" | awk -F\" '/^ *"name": "/{print $4;exit}' || :)"
-fi
-if [ -z "$RASPOTIFY_GIT_VER" ]; then
-	echo 'Could not obtain latest tag from upstream repository either. Exiting ...'
-	exit 1
+	# Derive from origin URL whether this is dtcooper/raspotify and hence supposed to have tags.
+	# If so, exit right here, else get tags from dtcooper/raspotify via GitHub API, since forks often do not have any tags.
+	url="$(git remote get-url origin || :)"
+	if [ "$url" = 'https://github.com/dtcooper/raspotify' ] || [ "$url" = 'https://github.com/dtcooper/raspotify/' ] || [ "$url" = 'https://github.com/dtcooper/raspotify.git' ]; then
+		echo 'E: Could not obtain any tag. Exiting ...'
+		exit 1
+	else
+		echo 'W: Could not obtain latest tag from local repository. Obtaining it from upstream: https://api.github.com/repos/dtcooper/raspotify/tags'
+		RASPOTIFY_GIT_VER="$(curl -sSf  "https://api.github.com/repos/dtcooper/raspotify/tags" | awk -F\" '/^ *"name": "/{print $4;exit}' || :)"
+		if [ -z "$RASPOTIFY_GIT_VER" ]; then
+			echo 'E: Could not obtain latest tag from upstream repository either. Exiting ...'
+			exit 1
+		fi
+	fi
 fi
 RASPOTIFY_HASH="$(git rev-parse HEAD | cut -c 1-7 || echo unknown)"
 


### PR DESCRIPTION
as well as a dependabot config to update used actions in workflows.

When building from a fork, tags may not exist. Try to obtain latest tag from upstream via GitHub API in this case. Exit early if this fails as well, as DEB packages strictly require their version to start with an integer. For debugging reasons, error output is unmuted.

As we talked about it, as a start 🙂.

I took the `if:` logic of the workflow from our repos:
- I personally want tests to run transparently on PR updates from fork branches, as well as on pushes to fork branches, which do not have a related PR.
- Adding both triggers however leads to duplicates, when opening a PR with a branch from the own repo: tests run for the push, as well as for the PR update.
- Using the push trigger only, runs the test on the fork repo (if it is from a fork), hence results do not show up and cannot be handled in the PR on the upstream/base repo.
- Only solution I found is to add both triggers, but add this condition so that the PR-triggered tests run only, if the PR is from a fork.
- As result:
  - the push triggered test runs always, hence on the own repo, if the branch is on the own repo, else on the fork. So people who work on their fork can also check and rerun tests on their own repo, like they run on my fork here now on every push: https://github.com/MichaIng/raspotify/actions
  - the PR triggered test runs only, if the PR has a fork as head. So test results can be seen and handled right within the PR. I am actually not sure if this happens as well, when the PR itself adds the test, hence if it does not exist on the base yet. So it might not be shown right here. Let's see ...
    EDIT: Oh nice, they do show up right here. So yeah, these are the "pull_request" triggered tests, intended to run only if the PR is from a fork, like in this case. When you open an internal PR, or push to any branch on your repo, a set of "push" triggered tests is supposed to run instead. And once the PR has been merged into the repos main branch, you can also manually trigger them for any branch from the actions panel, as I added the "workflow_dispatch" trigger as well: https://github.com/dtcooper/raspotify/actions