### PR TITLE
control.debian.tmpl/libasound: allow libasoundt64 for trixie t64

### DIFF
--- a/control.debian.tmpl
+++ b/control.debian.tmpl
@@ -4,7 +4,7 @@ Section: base
 Priority: optional
 Installed-Size: ${INSTALLED_SIZE}
 Architecture: ${ARCHITECTURE}
-Depends: libc6 (>= 2.31), coreutils (>= 8.32), libasound2 (>= 1.2.4), avahi-daemon (>= 0.8), alsa-utils (>= 1.2.4), libpulse0 (>= 14.2), systemd (>= 247.3), init-system-helpers (>= 1.60)
+Depends: libc6 (>= 2.31), coreutils (>= 8.32), libasound2 (>= 1.2.4) | libasound2t64 (>= 1.2.4), avahi-daemon (>= 0.8), alsa-utils (>= 1.2.4), libpulse0 (>= 14.2), systemd (>= 247.3), init-system-helpers (>= 1.60)
 Maintainer: ${RASPOTIFY_AUTHOR}
 Homepage: https://github.com/dtcooper/raspotify
 Vcs-Browser: https://github.com/dtcooper/raspotify


### PR DESCRIPTION
Fixes #715.
Have built and tested on my Pi 2B running trixie and it intalled fine!