### PR TITLE
fix: prevent OnFailure from causing endless loop on shutdown

### DIFF
--- a/raspotify/lib/systemd/system/raspotify-crash-report-generator.service
+++ b/raspotify/lib/systemd/system/raspotify-crash-report-generator.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Raspotify Crash Report Generator
+# Prevent this script if shutdown has been scheduled
+ConditionPathExists=!/run/systemd/shutdown/scheduled
 
 [Service]
 Type=oneshot

--- a/raspotify/lib/systemd/system/raspotify.service
+++ b/raspotify/lib/systemd/system/raspotify.service
@@ -5,9 +5,11 @@ Documentation=https://github.com/librespot-org/librespot
 Documentation=https://github.com/dtcooper/raspotify/wiki
 Documentation=https://github.com/librespot-org/librespot/wiki/Options
 Wants=network.target sound.target
-After=network.target sound.target
+After=network.target sound.target avahi-daemon.service dbus.service dbus-broker.service
 
 OnFailure=raspotify-crash-report-generator.service
+StartLimitIntervalSec=120s
+StartLimitBurst=6
 
 [Service]
 DynamicUser=no

--- a/raspotify/usr/bin/raspotify-crash-report-generator.sh
+++ b/raspotify/usr/bin/raspotify-crash-report-generator.sh
@@ -10,7 +10,7 @@ password="LIBRESPOT_PASSWORD"
 
 librespot="LIBRESPOT_"
 
-logs=$(journalctl -u raspotify --since "1min ago" -q)
+logs=$(journalctl -u raspotify --since "2min ago" -q)
 
 fail_count=$(echo "$logs" | grep -o "raspotify.service: Failed" | wc -l)
 
@@ -50,8 +50,6 @@ done <$config
 	echo -e "\n-- Ouput of librespot -d ? --"
 	librespot -d "?"
 } >>$crash_report 2>/dev/null
-
-systemctl reset-failed raspotify
 
 if [ "$fail_count" -lt 6 ]; then
 	sleep 10


### PR DESCRIPTION
Nothing prevents the `OnFailure` unit from starting even after a shutdown has been scheduled.

Raspotify is not assured to start after DBus has been started, and hence it is possible that DBus is stopped on shutdown before Raspotify. In this case, Raspotify fails with an error moreless immediately:
```
[librespot_discovery] Avahi error: Setting up dns-sd failed: DBus disappeared
```

This failure causes the `OnFailure` script to start, which starts Raspotify again, which immediately fails for the same reason, triggering `OnFailure` another time.

Since the `OnFailure` script sleeps for 10 seconds, it overall takes more 10 seconds to run. It checks its own logs from within the last minute, which hence can never contain the last 6 Raspotify failures, but max 5. It is hence assured to loop forever, always seeing less than 6 previous failures, and assuring this by watching only the last minute of logs. Furthermore systemd's own default startup burst prevention is actively undermined by resetting Raspotify's fail counter.

This commit tackles the fragile nature of ths `OnFailure` script in several ways:

1. It prevents the unit from starting if a shutdown has been scheduled. systemd creates `/run/systemd/shutdown/scheduled` in this case, which can be checked to not exist as a unit contrition.
2. It is made possible for the script to see 6 or more Raspotify failures by raising the logs period to watch 2 minutes.
3. The Raspotify unit gets a startup burst prevention defined for the same max 6 failures in 2 minutes, and the `OnFailure` unit won't reset this counter anymore.
4. The particular reason for the failure I faced is prevented, by ordering Raspotify to start after DBus. This implies that it is stopped on shutdown before DBus, not failing for this reason in the first place. Furthermore, since it emits a warning if Avahi-Daemon is not reachable, it is ordered after that one as well.