### PR TITLE
installer: fix recent Debian and Ubuntu versions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,20 +3,19 @@
 set -e
 
 SOURCE_REPO="deb [signed-by=/usr/share/keyrings/raspotify_key.asc] https://dtcooper.github.io/raspotify raspotify main"
-ERROR_MESG="Please make sure you are running a compatible armhf (ARMv7), arm64, or amd64 Debian based OS."
+ERROR_MESG="Please make sure you are running a compatible armhf (ARMv7), arm64, amd64 or riscv64 Debian based OS."
 
 LIBC_MIN_VER="2.31"
 CUTILS_MIN_VER="8.32"
 SYSTEMD_MIN_VER="247.3"
 HELPER_MIN_VER="1.6"
-LIBASOUND_MIN_VER="1.2.4"
 ALSA_UTILS_VER="1.2.4"
 LIBPULSE_MIN_VER="14.2"
 
 SUDO="sudo"
 APT="apt"
 
-REQ_PACKAGES="libc6 coreutils systemd init-system-helpers libasound2 alsa-utils libpulse0"
+REQ_PACKAGES="libc6 coreutils systemd init-system-helpers alsa-utils libpulse0"
 
 PACKAGES_TO_INSTALL=
 MIN_NOT_MET=
@@ -31,7 +30,7 @@ if ! which apt >/dev/null; then
 	fi
 fi
 
-if uname -a | grep -F -ivq -e armv7 -e aarch64 -e x86_64; then
+if uname -a | grep -F -ivq -e armv7 -e aarch64 -e x86_64 -e riscv64; then
 	echo "\nUnspported architecture:\n"
 	echo "$ERROR_MESG"
 	echo "\nSupport for ARMv6 (Pi v1 and Pi Zero v1.x) has been dropped."
@@ -73,9 +72,6 @@ for package in $REQ_PACKAGES; do
 		;;
 	"systemd")
 		MIN_VER=$SYSTEMD_MIN_VER
-		;;
-	"libasound2")
-		MIN_VER=$LIBASOUND_MIN_VER
 		;;
 	"alsa-utils")
 		MIN_VER=$ALSA_UTILS_VER


### PR DESCRIPTION
and add support for riscv64.

Ubuntu 24.04 Noble and Debian 13 Trixie made the 64-bit `time_t` transition, and the breaking API change due to related `time64` syscalls on 32-bit systems is expressed with a t64 suffix in library package names. `libasound2` has hence been renamed to `libasound2t64`.

On 64-bit systems, where `time_t` values were 64-bit before, the transition is a noop, and hence related packages "provide" the old ones. Hence `apt install libasound2` on 64-bit systems still works, being satisfied by the actually existing `libasound2t64`. But on 32-bit systems this command fails.

However, `libasound2` on Ubuntu is also "provided" by an alternative package `liboss4-salsa-asound2`, and the same is available on Debian Forky/testing. With multiple alternative "providers" for an only virtual package defined as dependency, APT denies to do the choice, but requires one of the providers to be chosen directly. This additionally breaks `apt install libasound2` on 64-bit systems on any Ubuntu or Debian version with `libasound2t64` and `liboss4-salsa-asound2` both available.

The solution applied is was to remove `libasound2` from explicit dependencies. The correct `libasound2` variant is a dependency of `alsa-utils` on all Debian and Ubuntu versions, and both always share the same version string. Since `alsa-utils` is explicitly installed as dependency, and its version checked, `libasound2` is hence not required.

An alternative solution would be to remove all these dependencies from the installer. They are actually all not required since the `raspotify` package itself declares everything already, for APT to require and pull the required dependencies automatically. In case of an `apt-get` failure, on top of its own error message, the general information about which architectures are support could still be printed, and a cleanup/removal of APT key+list done.