### PR TITLE
installer: remove manual dependency installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,29 +5,12 @@ set -e
 SOURCE_REPO="deb [signed-by=/usr/share/keyrings/raspotify_key.asc] https://dtcooper.github.io/raspotify raspotify main"
 ERROR_MESG="Please make sure you are running a compatible armhf (ARMv7), arm64, amd64 or riscv64 Debian based OS."
 
-LIBC_MIN_VER="2.31"
-CUTILS_MIN_VER="8.32"
-SYSTEMD_MIN_VER="247.3"
-HELPER_MIN_VER="1.6"
-ALSA_UTILS_VER="1.2.4"
-LIBPULSE_MIN_VER="14.2"
-
 SUDO="sudo"
-APT="apt"
 
-REQ_PACKAGES="libc6 coreutils systemd init-system-helpers alsa-utils libpulse0"
-
-PACKAGES_TO_INSTALL=
-MIN_NOT_MET=
-
-if ! which apt >/dev/null; then
-	APT="apt-get"
-
-	if ! which apt-get >/dev/null; then
-		echo "\nUnspported OS:\n"
-		echo "$ERROR_MESG"
-		exit 1
-	fi
+if ! which apt-get >/dev/null; then
+	echo "\nUnspported OS:\n"
+	echo "$ERROR_MESG"
+	exit 1
 fi
 
 if uname -a | grep -F -ivq -e armv7 -e aarch64 -e x86_64 -e riscv64; then
@@ -51,59 +34,12 @@ if ! which sudo >/dev/null; then
 	fi
 fi
 
-for package in $REQ_PACKAGES; do
-	if ! dpkg-query -W -f='${db:Status-Status}\n' "$package" 2>/dev/null | grep -q '^installed$'; then
-		PACKAGES_TO_INSTALL="$PACKAGES_TO_INSTALL $package"
-	fi
-done
-
-if [ "$PACKAGES_TO_INSTALL" ]; then
-	$SUDO $APT update
-	$SUDO $APT -y install $PACKAGES_TO_INSTALL
-fi
-
-for package in $REQ_PACKAGES; do
-	case "$package" in
-	"libc6")
-		MIN_VER=$LIBC_MIN_VER
-		;;
-	"coreutils")
-		MIN_VER=$CUTILS_MIN_VER
-		;;
-	"systemd")
-		MIN_VER=$SYSTEMD_MIN_VER
-		;;
-	"alsa-utils")
-		MIN_VER=$ALSA_UTILS_VER
-		;;
-	"libpulse0")
-		MIN_VER=$LIBPULSE_MIN_VER
-		;;
-	"init-system-helpers")
-		MIN_VER=$HELPER_MIN_VER
-		;;
-	esac
-
-	VER="$(dpkg-query -W -f='${Version}' $package)"
-
-	if eval dpkg --compare-versions "$VER" lt "$MIN_VER"; then
-		MIN_NOT_MET="$MIN_NOT_MET$package >= $MIN_VER is required but $VER is installed.\n"
-	fi
-done
-
-if [ "$MIN_NOT_MET" ]; then
-	echo "\nUnmet minimum required package version(s):\n"
-	echo "$MIN_NOT_MET"
-	echo "$ERROR_MESG"
-	exit 1
-fi
-
-curl -sSL https://dtcooper.github.io/raspotify/key.asc | $SUDO tee /usr/share/keyrings/raspotify_key.asc >/dev/null
+$SUDO curl -sSfL https://dtcooper.github.io/raspotify/key.asc -o /usr/share/keyrings/raspotify_key.asc
 $SUDO chmod 644 /usr/share/keyrings/raspotify_key.asc
 echo "$SOURCE_REPO" | $SUDO tee /etc/apt/sources.list.d/raspotify.list
 
-$SUDO $APT update
-$SUDO $APT -y install raspotify
+$SUDO apt-get update
+$SUDO apt-get -y install raspotify
 
 echo "\nThanks for installing Raspotify! Don't forget to checkout the wiki for tips, tricks and configuration info!:\n"
 echo "https://github.com/dtcooper/raspotify/wiki"


### PR DESCRIPTION
This is not needed, since the DEB package declares all dependencies properly and APT installs them automatically.

Aside of reducing maintenance efforts, a benefit on admin end is that dependencies which were installed for Raspotify only, can be `apt autopurge`d.

Fixes #752

Also, the installer uses now `apt-get` in any case. `apt` is not intended to be used in scripts, and throws a warning if not attached to an interactive terminal:
```
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```

And finally, add the `-f`/`--fail` flag to the `curl` call. That way, in case of HTTP errors, a one-line error message is printed to STDERR, hence no HTML error-document is stored to the key file: <https://manpages.debian.org/curl#f,>
To also prevent an existing key from being emptied on error, the `-o` option is used to store the successful download, instead of piping STDOUT.

Let me know if I should split the other changes out, I was just in the flow and found especially the key download hardening to be valuable.

Actually the installer (and thereby the repo) could be tested via GitHub Actions, just quick&dirty on the plain Ubuntu and Ubuntu ARM runners or so 🤔.