### PR TITLE
fix: redact access token and proxy credentials from crash reports

### DIFF
--- a/raspotify/lib/systemd/system/raspotify-crash-report-generator.service
+++ b/raspotify/lib/systemd/system/raspotify-crash-report-generator.service
@@ -5,4 +5,5 @@ ConditionPathExists=!/run/systemd/shutdown/scheduled
 
 [Service]
 Type=oneshot
+UMask=0077
 ExecStart=/usr/bin/raspotify-crash-report-generator.sh

--- a/raspotify/usr/bin/raspotify-crash-report-generator.sh
+++ b/raspotify/usr/bin/raspotify-crash-report-generator.sh
@@ -4,9 +4,11 @@ crash_report="/etc/raspotify/crash_report"
 
 config="/etc/raspotify/conf"
 
-# We don't want user names or passwords in the crash report.
+# We don't want credentials in the crash report.
 username="LIBRESPOT_USERNAME"
 password="LIBRESPOT_PASSWORD"
+access_token="LIBRESPOT_ACCESS_TOKEN"
+proxy="LIBRESPOT_PROXY"
 
 librespot="LIBRESPOT_"
 
@@ -32,6 +34,12 @@ while read -r line; do
 		;;
 	$password*)
 		echo "$password=XXXXXXXX" >>$crash_report 2>/dev/null
+		;;
+	$access_token*)
+		echo "$access_token=XXXXXXXX" >>$crash_report 2>/dev/null
+		;;
+	$proxy*)
+		echo "$proxy=XXXXXXXX" >>$crash_report 2>/dev/null
 		;;
 	$librespot*)
 		echo "$stripped_line" >>$crash_report 2>/dev/null


### PR DESCRIPTION
`raspotify-crash-report-generator.sh` only redacts `LIBRESPOT_USERNAME` and `LIBRESPOT_PASSWORD` before copying config lines into `/etc/raspotify/crash_report`. Every other `LIBRESPOT_*` variable is copied verbatim, including `LIBRESPOT_ACCESS_TOKEN` (an alternative to username/password auth) and `LIBRESPOT_PROXY` (which can embed `user:pass@host` credentials in the proxy URL). Anyone who sets either of these and hits a crash ends up with a plaintext credential sitting in the crash report.

This adds the same `XXXXXXXX` redaction for both variables.

Also adds `UMask=0077` to `raspotify-crash-report-generator.service`, matching the main `raspotify.service`. Without it, the crash report file is created world-readable (mode 644) since the unit inherits the default umask, so any local user could read it even before considering the credential leak above.