### PR TITLE
build: export RUST_VERSION so package description isn't blank

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -74,8 +74,10 @@ packages() {
 	INSTALLED_SIZE="$((($(du -bs raspotify --exclude=raspotify/DEBIAN/control | cut -f 1) + 2048) / 1024))"
 
 	echo "Generate Debian control..."
+	RUST_VERSION="$(rustc -V | cut -d' ' -f2-)"
 	export DEB_PKG_VER
 	export INSTALLED_SIZE
+	export RUST_VERSION
 	envsubst <control.debian.tmpl >raspotify/DEBIAN/control
 
 	echo "Build Raspotify deb..."


### PR DESCRIPTION
The Debian package description ends with `[Built with rustc ]` for every build, since `RUST_VERSION` referenced in `control.debian.tmpl` is never set before the `envsubst` call in `build.sh`.

This regressed in afb86cf (Dec 2022), when the project moved off jinja2 templating to `envsubst`. The `export RUST_VER=$(rustc -V)` line was dropped from `build.sh` in that commit, and the template's placeholder was simultaneously renamed back to `${RUST_VERSION}` in the same commit. The two edits didn't match, so the variable has been unset ever since.

Verified locally with `make amd64`. Before: `Description: ... [Built with rustc ]`. After: `Description: ... [Built with rustc 1.98.0 (88d9e12ae 2026-08-18)]`.