### PR TITLE
docs: fix typos in README, issue templates, and crash report script

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
       value: |
         Thank you for taking the time to fill out this bug report.
 
-        Please take the time to read the [README](https://github.com/dtcooper/raspotify#readme) and [Wiki](https://github.com/dtcooper/raspotify/wiki), in particular the [Basic Setup Guide](https://github.com/dtcooper/raspotify/wiki/Basic-Setup-Guide) and the [Troubleshooting](https://github.com/dtcooper/raspotify/wiki/Troubleshooting) section and search though open and closed [isssues](https://github.com/dtcooper/raspotify/issues).
+        Please take the time to read the [README](https://github.com/dtcooper/raspotify#readme) and [Wiki](https://github.com/dtcooper/raspotify/wiki), in particular the [Basic Setup Guide](https://github.com/dtcooper/raspotify/wiki/Basic-Setup-Guide) and the [Troubleshooting](https://github.com/dtcooper/raspotify/wiki/Troubleshooting) section and search through open and closed [issues](https://github.com/dtcooper/raspotify/issues).
         
         **Duplicates and/or issues that can easily be solved by reading said information will be closed with little to no explanation.**
   - type: checkboxes
@@ -61,7 +61,7 @@ body:
     id: due-diligence
     attributes:
       label: Due Diligence
-      description: Before submitting this issue you have made sure to read the README, wiki and seach though the issues (open and closed) 
+      description: Before submitting this issue you have made sure to read the README, wiki and search through the issues (open and closed)
       options:
         - label: I have done my due diligence
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request_or_idea.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_or_idea.yml
@@ -6,9 +6,9 @@ body:
       value: |
         Thank you for taking the time to fill out this feature request.
 
-        Please take the time to read the [README](https://github.com/dtcooper/raspotify#readme), [Wiki](https://github.com/dtcooper/raspotify/wiki) and search though open and closed [isssues](https://github.com/dtcooper/raspotify/issues).
+        Please take the time to read the [README](https://github.com/dtcooper/raspotify#readme), [Wiki](https://github.com/dtcooper/raspotify/wiki) and search through open and closed [issues](https://github.com/dtcooper/raspotify/issues).
         
-        **Raspotify is a packaged version of [librespot](https://github.com/librespot-org/librespot) if your feature request is not releated to packaging it's most likely out of scope.** 
+        **Raspotify is a packaged version of [librespot](https://github.com/librespot-org/librespot) if your feature request is not related to packaging it's most likely out of scope.** 
   - type: checkboxes
     id: is-a-package
     attributes:
@@ -21,7 +21,7 @@ body:
     id: due-diligence
     attributes:
       label: Due Diligence
-      description: Before submitting this feature request you have made sure to read the README, wiki and seach though the issues (open and closed) 
+      description: Before submitting this feature request you have made sure to read the README, wiki and search through the issues (open and closed) 
       options:
         - label: I have done my due diligence
           required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -6,14 +6,14 @@ body:
       value: |
         Thank you for taking the time to ask your question.
 
-        Please take the time to read the [README](https://github.com/dtcooper/raspotify#readme), [Wiki](https://github.com/dtcooper/raspotify/wiki) and search though open and closed [isssues](https://github.com/dtcooper/raspotify/issues).
+        Please take the time to read the [README](https://github.com/dtcooper/raspotify#readme), [Wiki](https://github.com/dtcooper/raspotify/wiki) and search through open and closed [issues](https://github.com/dtcooper/raspotify/issues).
         
         **Duplicates and/or questions that can easily be answered by reading said information will be closed with little to no explanation.** 
   - type: checkboxes
     id: due-diligence
     attributes:
       label: Due Diligence
-      description: Before asking this question you have made sure to read the README, wiki and seach though the issues (open and closed) 
+      description: Before asking this question you have made sure to read the README, wiki and search through the issues (open and closed)
       options:
         - label: I have done my due diligence
           required: true

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and other Debian Stable based/compatible OS's (**your mileage may vary**) which 
 [librespot](https://github.com/librespot-org/librespot) library by [Paul Lietar](https://github.com/plietar) and others as a
 [systemd](https://en.wikipedia.org/wiki/Systemd) [daemon](https://en.wikipedia.org/wiki/Daemon_(computing)).
 
-Raspotify is intended to be used in a *[headless enviroment](https://en.wikipedia.org/wiki/Headless_computer)*. For desktop OS's [spotifyd](https://github.com/Spotifyd/spotifyd) offers similar functionality and is a better choice. If you're looking for a turnkey audio solution for Raspberry Pi's with Spotify Connect support we recommend [moOde™ audio player](https://moodeaudio.org/).
+Raspotify is intended to be used in a *[headless environment](https://en.wikipedia.org/wiki/Headless_computer)*. For desktop OS's [spotifyd](https://github.com/Spotifyd/spotifyd) offers similar functionality and is a better choice. If you're looking for a turnkey audio solution for Raspberry Pi's with Spotify Connect support we recommend [moOde™ audio player](https://moodeaudio.org/).
 
 **Librespot, and therefore Raspotify, requires a premium account.**
 

--- a/raspotify/usr/bin/raspotify-crash-report-generator.sh
+++ b/raspotify/usr/bin/raspotify-crash-report-generator.sh
@@ -51,11 +51,11 @@ while read -r line; do
 done <$config
 
 {
-	echo -e "\n-- Ouput of aplay -l --\n"
+	echo -e "\n-- Output of aplay -l --\n"
 	aplay -l
-	echo -e "\n-- Ouput of aplay -L --\n"
+	echo -e "\n-- Output of aplay -L --\n"
 	aplay -L
-	echo -e "\n-- Ouput of librespot -d ? --"
+	echo -e "\n-- Output of librespot -d ? --"
 	librespot -d "?"
 } >>$crash_report 2>/dev/null
 


### PR DESCRIPTION
Fixes a handful of typos across the README, GitHub issue templates, and the crash report generator script: "headless enviroment" -> "environment", "Ouput" -> "Output" (the crash report's section headers, x3), and "search though" / "isssues" / "releated" -> "search through" / "issues" / "related" across all three issue templates.

Pure typo fixes, no functional or behavioral changes.