### PR TITLE
build: use native-tls on all targets but riscv64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM rust:bullseye
+FROM rust:bookworm
 
+# PKG_CONFIG_PATH is deliberately not set here: it applies to every target, so a
+# single arch's dir would be searched first for all of them. build.sh sets it
+# per-arch alongside BUILD_TARGET instead.
 ENV INSIDE_DOCKER_CONTAINER=1 \
     DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NOWARNINGS=yes \
     PKG_CONFIG_ALLOW_CROSS=1 \
-    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabihf/pkgconfig" \
     PATH="/root/.cargo/bin/:$PATH" \
     CARGO_INSTALL_ROOT="/root/.cargo" \
     CARGO_TARGET_DIR="/build" \
@@ -18,12 +20,15 @@ RUN dpkg --add-architecture arm64 \
         build-essential \
         libasound2-dev \
         libpulse-dev \
+        libssl-dev \
         crossbuild-essential-arm64 \
         libasound2-dev:arm64 \
         libpulse-dev:arm64 \
+        libssl-dev:arm64 \
         crossbuild-essential-armhf \
         libasound2-dev:armhf \
         libpulse-dev:armhf \
+        libssl-dev:armhf \
         cmake \
         clang-16 \
         git \

--- a/build.sh
+++ b/build.sh
@@ -60,8 +60,12 @@ packages() {
 	DEB_PKG_NAME="raspotify_${DEB_PKG_VER}_${ARCHITECTURE}.deb"
 	echo "Prepare to build ${DEB_PKG_NAME}"
 
-	echo "Build Librespot binary..."
-	cargo build --jobs "$(nproc)" --profile release --target "$BUILD_TARGET" --no-default-features --features "alsa-backend pulseaudio-backend with-avahi rustls-tls-native-roots"
+	# Overridable so an arch that can't use native-tls (OpenSSL) can swap in
+	# rustls, and vice versa.
+	CARGO_FEATURES="${CARGO_FEATURES:-alsa-backend pulseaudio-backend with-avahi native-tls}"
+
+	echo "Build Librespot binary (features: $CARGO_FEATURES)..."
+	cargo build --jobs "$(nproc)" --profile release --target "$BUILD_TARGET" --no-default-features --features "$CARGO_FEATURES"
 
 	echo "Copy Librespot binary to package root..."
 	cd /mnt/raspotify
@@ -75,6 +79,12 @@ packages() {
 
 	echo "Generate Debian control..."
 	RUST_VERSION="$(rustc -V | cut -d' ' -f2-)"
+	# The Debian architecture in the control file, for when it differs from the
+	# name we build under.
+	export DEB_ARCH="${DEB_ARCH:-$ARCHITECTURE}"
+	# native-tls links OpenSSL, so those arches need the libssl dependency that a
+	# rustls build must not declare.
+	export DEB_EXTRA_DEPENDS="${DEB_EXTRA_DEPENDS-, libssl3t64 (>= 3.0.0) | libssl3 (>= 3.0.0)}"
 	export DEB_PKG_VER
 	export INSTALLED_SIZE
 	export RUST_VERSION
@@ -129,24 +139,33 @@ packages() {
 build_armhf() {
 	ARCHITECTURE="armhf"
 	BUILD_TARGET="armv7-unknown-linux-gnueabihf"
+	export PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabihf/pkgconfig"
 	packages
 }
 
 build_arm64() {
 	ARCHITECTURE="arm64"
 	BUILD_TARGET="aarch64-unknown-linux-gnu"
+	export PKG_CONFIG_PATH="/usr/lib/aarch64-linux-gnu/pkgconfig"
 	packages
 }
 
 build_amd64() {
 	ARCHITECTURE="amd64"
 	BUILD_TARGET="x86_64-unknown-linux-gnu"
+	export PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig"
 	packages
 }
 
 build_riscv64() {
 	ARCHITECTURE="riscv64"
 	BUILD_TARGET="riscv64gc-unknown-linux-gnu"
+	export PKG_CONFIG_PATH="/usr/lib/riscv64-linux-gnu/pkgconfig"
+	# Dockerfile.riscv64 installs no OpenSSL, so this is the one arch that can't
+	# use native-tls; rustls reads the same system CA store, and declares no
+	# libssl dependency.
+	CARGO_FEATURES="alsa-backend pulseaudio-backend with-avahi rustls-tls-native-roots"
+	DEB_EXTRA_DEPENDS=""
 	packages
 }
 

--- a/control.debian.tmpl
+++ b/control.debian.tmpl
@@ -3,8 +3,8 @@ Version: ${DEB_PKG_VER}
 Section: base
 Priority: optional
 Installed-Size: ${INSTALLED_SIZE}
-Architecture: ${ARCHITECTURE}
-Depends: libc6 (>= 2.31), coreutils (>= 8.32), libasound2t64 (>= 1.2.4) | libasound2 (>= 1.2.4), avahi-daemon (>= 0.8), alsa-utils (>= 1.2.4), libpulse0 (>= 14.2), systemd (>= 247.3), init-system-helpers (>= 1.60)
+Architecture: ${DEB_ARCH}
+Depends: libc6 (>= 2.36), coreutils (>= 8.32), libasound2t64 (>= 1.2.4) | libasound2 (>= 1.2.4), avahi-daemon (>= 0.8), alsa-utils (>= 1.2.4), libpulse0 (>= 14.2), systemd (>= 247.3), init-system-helpers (>= 1.60)${DEB_EXTRA_DEPENDS}
 Maintainer: ${RASPOTIFY_AUTHOR}
 Homepage: https://github.com/dtcooper/raspotify
 Vcs-Browser: https://github.com/dtcooper/raspotify


### PR DESCRIPTION
This pull request updates the build system and packaging to improve multi-architecture support, especially around OpenSSL and TLS backend selection. The changes make the Docker and build scripts more flexible and robust by allowing per-architecture configuration of dependencies and features, and by ensuring the correct runtime dependencies are declared for each build. Also - dockerfile is updated to bookworm